### PR TITLE
Fix validation stable eval for tensor outputs

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -69,6 +69,7 @@ from accelerate import Accelerator
 import transformers
 import diffusers
 import hashlib
+from toolkit.prompt_utils import PromptEmbeds
 
 from toolkit.util.blended_blur_noise import get_blended_blur_noise
 from toolkit.util.get_model import get_model_class
@@ -1441,6 +1442,9 @@ class BaseSDTrainProcess(BaseTrainProcess):
                         )
                     else:
                         text_embeddings = self.sd.encode_prompt(conditioned_prompts)
+
+                if not hasattr(text_embeddings, 'text_embeds'):
+                    text_embeddings = PromptEmbeds(text_embeddings)
 
                 with self.timer('predict_noise'):
                     noise_pred = self.sd.predict_noise(


### PR DESCRIPTION
## Summary
- ensure stable validation handles tensor embeddings
- import `PromptEmbeds` in training process

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68499514b0b88323b963bd39be917a36