### PR TITLE
Fix stable validation noise prediction

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -1449,8 +1449,8 @@ class BaseSDTrainProcess(BaseTrainProcess):
                 with self.timer('predict_noise'):
                     noise_pred = self.sd.predict_noise(
                         noisy_latents,
-                        timesteps,
                         text_embeddings,
+                        timesteps,
                         guidance_scale=1.0
                     )
 


### PR DESCRIPTION
## Summary
- fix argument order for `predict_noise` during stable evaluation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68499646ea488323b5c1b1ef88e58bcb