### PR TITLE
Improve stable evaluation error message

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -1447,12 +1447,21 @@ class BaseSDTrainProcess(BaseTrainProcess):
                     text_embeddings = PromptEmbeds(text_embeddings)
 
                 with self.timer('predict_noise'):
-                    noise_pred = self.sd.predict_noise(
-                        noisy_latents,
-                        text_embeddings,
-                        timesteps,
-                        guidance_scale=1.0
-                    )
+                    try:
+                        noise_pred = self.sd.predict_noise(
+                            noisy_latents,
+                            text_embeddings,
+                            timesteps,
+                            guidance_scale=1.0
+                        )
+                    except RuntimeError as e:
+                        print(
+                            f"[Stable Eval] predict_noise failed: {e}\n"
+                            f"\tnoisy_latents: {tuple(noisy_latents.shape)}\n"
+                            f"\ttimesteps: {tuple(timesteps.shape)}\n"
+                            f"\ttext_embeds: {tuple(text_embeddings.text_embeds.shape)}"
+                        )
+                        raise
 
                 loss = torch.nn.functional.mse_loss(noise_pred, noise, reduction="mean")
 


### PR DESCRIPTION
## Summary
- add graceful error handling in `compute_stable_validation_loss`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6849985300c48323b976ed7c3101d00c