### PR TITLE
Fix patch size for Flex2 models

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -1153,10 +1153,7 @@ class BaseSDTrainProcess(BaseTrainProcess):
                         timestep_type = 'shift'
                     
                     patch_size = 1
-                    if self.sd.is_flux or 'flex' in self.sd.arch:
-                        # flux is a patch size of 1, but latents are divided by 2, so we need to double it
-                        patch_size = 2
-                    elif hasattr(self.sd.unet.config, 'patch_size'):
+                    if hasattr(self.sd.unet.config, 'patch_size'):
                         patch_size = self.sd.unet.config.patch_size
                     
                     self.sd.noise_scheduler.set_train_timesteps(


### PR DESCRIPTION
## Summary
- handle variable patch sizes when computing noise predictions in `flex2.py`
- apply patch size from the model configuration during training setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68499dd285d08323a3b7fdf09aea4e34